### PR TITLE
Refocus site on landing page service marketing

### DIFF
--- a/src/components/AboutSection/AboutSection.jsx
+++ b/src/components/AboutSection/AboutSection.jsx
@@ -1,20 +1,20 @@
 import './AboutSection.css';
-import { skills } from '../../data';
+import { processSteps } from '../../data';
 
 const AboutSection = () => {
   return (
-    <section className="about-section fade-in" id="sobre-mi">
+    <section className="about-section fade-in" id="proceso">
       <div className="about-section__content">
-        <h2>Sobre mí</h2>
+        <h2>Así trabajaremos tu landing</h2>
         <p>
-          Soy Wahandri, un desarrollador web junior que transforma ideas en páginas modernas.
-          Me inspiran las atmósferas futuristas, el anime y la estética cyberpunk.
+          Un proceso claro y colaborativo para que te olvides de lo técnico y te concentres en
+          cerrar ventas.
         </p>
       </div>
-      <ul className="about-section__skills" aria-label="Habilidades principales">
-        {skills.map((skill) => (
-          <li key={skill} className="skill-tag">
-            {skill}
+      <ul className="about-section__skills" aria-label="Pasos del proceso">
+        {processSteps.map((step) => (
+          <li key={step} className="skill-tag">
+            {step}
           </li>
         ))}
       </ul>

--- a/src/components/ContactSection/ContactSection.jsx
+++ b/src/components/ContactSection/ContactSection.jsx
@@ -6,7 +6,9 @@ const ContactSection = () => {
     <section className="contact-section fade-in" id="contacto">
       <div className="section-header">
         <h2>Contacto</h2>
-        <p>¿Listo para impulsar tu proyecto? Conversemos.</p>
+        <p>
+          Reserva una llamada gratuita y recibe una propuesta personalizada en menos de 24 horas.
+        </p>
       </div>
       <div className="contact-section__content">
         <form className="contact-form">
@@ -23,11 +25,11 @@ const ContactSection = () => {
             <textarea name="mensaje" placeholder="Cuéntame sobre tu proyecto" rows="4" />
           </label>
           <button type="submit" className="button-glow contact-form__submit">
-            Enviar mensaje
+            Agendar llamada
           </button>
         </form>
         <div className="contact-section__sidebar">
-          <h3>Redes</h3>
+          <h3>Atención directa</h3>
           <ul className="contact-section__links">
             {socialLinks.map((link) => (
               <li key={link.id}>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -4,7 +4,7 @@ import { navLinks } from '../../data';
 const Footer = () => {
   return (
     <footer className="footer">
-      <p>© 2025 Wahandri - Desarrollador Web Freelance</p>
+      <p>© 2025 Wahandri - Landing pages que venden</p>
       <nav className="footer__nav" aria-label="Enlaces rápidos">
         {navLinks.map((link) => (
           <a key={link.id} href={`#${link.id}`} className="footer__link">

--- a/src/components/PortfolioSection/PortfolioSection.jsx
+++ b/src/components/PortfolioSection/PortfolioSection.jsx
@@ -1,22 +1,25 @@
 import './PortfolioSection.css';
-import { projects } from '../../data';
+import { benefits } from '../../data';
 
 const PortfolioSection = () => {
   return (
-    <section className="portfolio-section fade-in" id="portfolio">
+    <section className="portfolio-section fade-in" id="beneficios">
       <div className="section-header">
-        <h2>Portfolio</h2>
-        <p>Muestras de proyectos donde el estilo oscuro y creativo toma protagonismo.</p>
+        <h2>Beneficios de tu nueva web</h2>
+        <p>
+          Cada landing page está pensada para atraer, convencer y convertir a tus
+          visitantes en clientes reales.
+        </p>
       </div>
       <div className="portfolio-grid">
-        {projects.map((project) => (
-          <article key={project.id} className="portfolio-card">
+        {benefits.map((benefit) => (
+          <article key={benefit.id} className="portfolio-card">
             <div className="portfolio-card__image" aria-hidden="true">
               <div className="portfolio-card__placeholder" />
             </div>
             <div className="portfolio-card__content">
-              <h3>{project.title}</h3>
-              <p>{project.description}</p>
+              <h3>{benefit.title}</h3>
+              <p>{benefit.description}</p>
             </div>
           </article>
         ))}

--- a/src/components/ServicesSection/ServicesSection.css
+++ b/src/components/ServicesSection/ServicesSection.css
@@ -49,3 +49,11 @@
 .service-card__content p {
   color: var(--color-muted);
 }
+
+.service-card__price {
+  margin-top: 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-accent);
+  letter-spacing: 0.05em;
+}

--- a/src/components/ServicesSection/ServicesSection.jsx
+++ b/src/components/ServicesSection/ServicesSection.jsx
@@ -1,25 +1,26 @@
 import './ServicesSection.css';
-import { services } from '../../data';
+import { plans } from '../../data';
 
 const ServicesSection = () => {
   return (
-    <section className="services-section fade-in" id="servicios">
+    <section className="services-section fade-in" id="planes">
       <div className="section-header">
-        <h2>Servicios</h2>
-        <p>Soluciones enfocadas en darle vida digital a tu marca.</p>
+        <h2>Planes a la medida de tu lanzamiento</h2>
+        <p>Elige la propuesta que mejor se adapte al momento actual de tu negocio.</p>
         <p className="services-section__price-note">
-          Portfolio básico de una página por <strong>250€</strong>.
+          Todos los planes incluyen copywriting, diseño responsive y optimización SEO técnica.
         </p>
       </div>
       <div className="services-grid">
-        {services.map((service) => (
-          <article key={service.id} className="service-card">
+        {plans.map((plan) => (
+          <article key={plan.id} className="service-card">
             <div className="service-card__icon" aria-hidden="true">
               <span />
             </div>
             <div className="service-card__content">
-              <h3>{service.title}</h3>
-              <p>{service.description}</p>
+              <h3>{plan.title}</h3>
+              <p>{plan.description}</p>
+              <p className="service-card__price">{plan.price}</p>
             </div>
           </article>
         ))}

--- a/src/data.js
+++ b/src/data.js
@@ -1,85 +1,104 @@
 export const navLinks = [
   { id: 'inicio', label: 'Inicio' },
-  { id: 'portfolio', label: 'Portfolio' },
-  { id: 'servicios', label: 'Servicios' },
+  { id: 'beneficios', label: 'Beneficios' },
+  { id: 'planes', label: 'Planes' },
+  { id: 'proceso', label: 'Proceso' },
   { id: 'contacto', label: 'Contacto' },
 ];
 
 export const heroContent = {
-  title: 'Desarrollador Web Freelance',
-  subtitle: 'Diseño y desarrollo de landing pages creativas y modernas',
-  priceHighlight: 'Landing page básica de una página por 250€',
-  cta: 'Contáctame',
+  title: 'Landing pages que venden por ti',
+  subtitle:
+    'Transformo tu idea en una web lista para captar clientes en menos de 10 días.',
+  priceHighlight: 'Paquetes completos desde 250€ con copy y diseño incluidos.',
+  cta: 'Solicita tu propuesta',
 };
 
-export const projects = [
+export const benefits = [
   {
-    id: 'project-1',
-    title: 'Nebula Studio',
-    description: 'Landing page futurista para un estudio creativo digital.',
-    imageAlt: 'Nebula Studio preview',
+    id: 'benefit-1',
+    title: 'Diseño estratégico',
+    description:
+      'Maquetas pensadas para guiar la mirada, destacar tu propuesta de valor y aumentar conversiones.',
   },
   {
-    id: 'project-2',
-    title: 'Cafe Pixel',
-    description: 'Sitio web oscuro con menú interactivo para un coffee shop geek.',
-    imageAlt: 'Cafe Pixel preview',
+    id: 'benefit-2',
+    title: 'Velocidad de entrega',
+    description:
+      'Proceso ágil con revisiones claras para lanzar tu landing page en menos de 10 días.',
   },
   {
-    id: 'project-3',
-    title: 'Anime Verse',
-    description: 'Landing page para un blog de cultura anime y eventos.',
-    imageAlt: 'Anime Verse preview',
+    id: 'benefit-3',
+    title: 'Optimización completa',
+    description:
+      'SEO técnico, carga rápida y configuración de métricas listas para tus campañas.',
   },
   {
-    id: 'project-4',
-    title: 'CyberFit',
-    description: 'Plataforma fitness con estética cyberpunk para entrenadores online.',
-    imageAlt: 'CyberFit preview',
+    id: 'benefit-4',
+    title: 'Enfoque en resultados',
+    description:
+      'Textos persuasivos, formularios funcionales y automatizaciones básicas para captar leads.',
   },
   {
-    id: 'project-5',
-    title: 'Digital Nomad',
-    description: 'Landing promocional para un curso de productividad remota.',
-    imageAlt: 'Digital Nomad preview',
+    id: 'benefit-5',
+    title: 'Acompañamiento cercano',
+    description:
+      'Reunión de kick-off, actualizaciones por WhatsApp y soporte posterior al lanzamiento.',
   },
   {
-    id: 'project-6',
-    title: 'Synthwave Agency',
-    description: 'Sitio vibrante para agencia de marketing inspirada en synthwave.',
-    imageAlt: 'Synthwave Agency preview',
-  },
-];
-
-export const services = [
-  {
-    id: 'service-1',
-    title: 'Landing Pages Express',
-    description: 'Entregas rápidas y optimizadas para lanzar tu idea en tiempo récord.',
-  },
-  {
-    id: 'service-2',
-    title: 'Diseño Creativo',
-    description: 'Interfaces modernas con estética inspirada en Matrix, cyberpunk y anime.',
-  },
-  {
-    id: 'service-3',
-    title: 'Mantenimiento Web',
-    description: 'Soporte continuo para que tu landing se mantenga segura y actualizada.',
+    id: 'benefit-6',
+    title: 'Estética diferencial',
+    description:
+      'Una web con estilo futurista y profesional que refleje la personalidad de tu marca.',
   },
 ];
 
-export const skills = ['React', 'CSS', 'Node', 'MongoDB', 'PHP', 'Symfony'];
+export const plans = [
+  {
+    id: 'plan-1',
+    title: 'Lanzamiento Esencial',
+    description:
+      'Landing de una sección con copy base, formulario de contacto y hasta 3 bloques visuales.',
+    price: '250€',
+  },
+  {
+    id: 'plan-2',
+    title: 'Impulso Comercial',
+    description:
+      'Landing multisección con secciones de beneficios, testimonios y conexión con tus campañas.',
+    price: '420€',
+  },
+  {
+    id: 'plan-3',
+    title: 'Escala Premium',
+    description:
+      'Experiencia completa con contenido a medida, integraciones avanzadas y soporte mensual.',
+    price: '620€',
+  },
+];
+
+export const processSteps = [
+  'Brief express para entender tu negocio y tu cliente ideal.',
+  'Prototipo en Figma para validar estructura, copy y estilo visual.',
+  'Desarrollo en React/Vite optimizado para velocidad y SEO.',
+  'Integración de analítica, formularios y revisión final antes del lanzamiento.',
+  'Entrega de tutorial en video y soporte gratuito durante 15 días.',
+];
 
 export const socialLinks = [
   {
-    id: 'github',
-    label: 'GitHub',
-    url: 'https://github.com/',
+    id: 'whatsapp',
+    label: 'WhatsApp',
+    url: 'https://wa.me/000000000',
   },
   {
-    id: 'linkedin',
-    label: 'LinkedIn',
-    url: 'https://www.linkedin.com/',
+    id: 'email',
+    label: 'Email',
+    url: 'mailto:hola@wahandri.com',
+  },
+  {
+    id: 'instagram',
+    label: 'Instagram',
+    url: 'https://www.instagram.com/',
   },
 ];


### PR DESCRIPTION
## Summary
- rewrite site copy to position the brand as a landing page creation service instead of a freelance portfolio
- replace portfolio grid with benefit highlights and update service section with pricing plans
- refresh process, contact, and footer content to reinforce marketing messaging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d60894dca08323b09a374512ea2297